### PR TITLE
java 8, move back to specs 3.6.1 due to warning of compatability to s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <specs2.version>3.7</specs2.version>
+        <specs2.version>3.6.1</specs2.version>
     </properties>
 
     <dependencies>
@@ -75,8 +75,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
             </plugins>
@@ -92,8 +92,8 @@
                         <arg>-deprecation</arg>
                     </args>
                     <addJavacArgs>-deprecation</addJavacArgs>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <executions>
                         <execution>


### PR DESCRIPTION
…cala version
